### PR TITLE
Update crypto library to 2.0.2

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -13,7 +13,7 @@ Getting Started
 ---------------
 Working on ``Neustar-TDI/python-sdk`` requires additional packages, such as `pytest`_, `mock`_ and `Sphinx`_.
 
-.. code-block:: console
+.. code:: console
 
   $ pip install -r dev_requirements
   $ pip install -e .
@@ -31,14 +31,14 @@ Running Tests
 Unit tests are found in the ``tests/`` directory and are designed to use python's
 ``unittest`` library. ``pytest`` will discover the tests automatically.
 
-.. code-block:: console
+.. code:: console
 
   $ pytest
 
 Cross-version tests require installing additional Python versions, and setting up the local
 ``tox`` environment:
 
-.. code-block:: console
+.. code:: console
 
   $ pyenv install 3.6.1
   $ pyenv install 3.5.1
@@ -52,7 +52,7 @@ Building Documentation
 Documentation is stored in the ``docs/`` directory. It is written
 in `reStructedText`_ and rendered using `Sphinx`_.
 
-.. code-block:: console
+.. code:: console
 
   $ make html
 
@@ -97,7 +97,7 @@ Contributing Changes
 * Our coding style follows `PEP 8`_.
 * In docstrings we use reStructedText as described in `PEP 287`_
 
-.. code-block:: python
+.. code:: python
 
   def foo(bar):
       """

--- a/docs/installation/device/intel-edison.rst
+++ b/docs/installation/device/intel-edison.rst
@@ -9,35 +9,35 @@ After you've flashed and configured your Intel Edison, we can setup the Intel Ed
 
 * Open the base-feeds config file:
 
-.. code-block:: console
+.. code:: console
 
-    vi /etc/opkg/base-feeds.conf
+    $ vi /etc/opkg/base-feeds.conf
 
 * Add the following repositories:
 
-.. code-block:: console
+.. code:: console
 
-    src/gz all http://repo.opkg.net/edison/repo/all
-    src/gz edison http://repo.opkg.net/edison/repo/edison
-    src/gz core2-32 http://repo.opkg.net/edison/repo/core2-32
+    $ src/gz all http://repo.opkg.net/edison/repo/all
+    $ src/gz edison http://repo.opkg.net/edison/repo/edison
+    $ src/gz core2-32 http://repo.opkg.net/edison/repo/core2-32
 
 * Update opkg:
 
-.. code-block:: console
+.. code:: console
 
-    opkg update
+    $ opkg update
 
 * Install python pip:
 
-.. code-block:: console
+.. code:: console
 
-    opkg install python-pip
+    $ opkg install python-pip
 
 * Install the SDK:
 
-.. code-block:: console
+.. code:: console
 
-    pip install oneid-connect
+    $ pip install oneid-connect
 
 
 

--- a/docs/installation/server/osx.rst
+++ b/docs/installation/server/osx.rst
@@ -3,7 +3,7 @@ Installation for Mac OS X
 The cryptography.io requirement is a statically linked build for Yosemite and above.
 You only need one step:
 
-.. code-block:: console
+.. code:: console
 
     $ pip install oneid-connect
 
@@ -11,7 +11,7 @@ If you're using an older version of OS X or want to link to a specific version
 of openSSL you will need a C compiler, development headers and possibly
 even the openSSL Library. This is all provided by Apple's Xcode development tools.
 
-.. code-block:: console
+.. code:: console
 
     $ xcode-select --install
 

--- a/docs/installation/server/ubuntu.rst
+++ b/docs/installation/server/ubuntu.rst
@@ -6,12 +6,12 @@ cryptography.io is a library that exposes cryptographic primitives from openSSL.
 The SDK should build easily on most Linux distributions that have a C compiler,
 openSSL headers and the ``libffi`` libraries.
 
-.. code-block:: console
+.. code:: console
 
     $ sudo apt-get install build-essential libssl-dev libffi-dev python-dev
 
 You should now be able to install the SDK with the usual
 
-.. code-block:: console
+.. code:: console
 
     $ pip install oneid-connect

--- a/docs/tutorials/firmware-update.rst
+++ b/docs/tutorials/firmware-update.rst
@@ -10,7 +10,7 @@ commission, you can easily revoke it's signing permissions.
 
 Before we begin, you will need ``oneID-cli`` and a `Neustar TDI developer account`_.
 
-.. code-block:: console
+.. code:: console
 
    $ pip install oneid-cli
 
@@ -39,9 +39,9 @@ Setup
 -----
 First we need to configure your terminal.
 
-.. code-block:: console
+.. code:: console
 
-   oneid-cli configure
+   $ oneid-cli configure
 
 This will prompt you for your ``ACCESS_KEY``, ``ACCESS_SECRET``, and ``ONEID_KEY``.
 You can find all these in your `Neustar TDI developer console`_
@@ -52,7 +52,7 @@ Creating a Project
 All users, servers and edge devices need to be associated with a Project.
 Let's create a new Project.
 
-.. code-block:: console
+.. code:: console
 
    $ oneid-cli create-project --name "my epic project"
 
@@ -84,7 +84,7 @@ and a checksum the IoT device will use to verify the download.
 Before we can sign any messages, we need to give the server an identity
 Neustar TDI can verify.
 
-.. code-block:: console
+.. code:: console
 
    $ oneid-cli provision --project-id d47fedd0-729f-4941-b4bd-2ec4fe0f9ca9 --name "IoT server" --type server
 
@@ -98,7 +98,7 @@ This will generate a new **SECRET** ``.pem`` file.
 If you created the server secret key on your personal computer, we need to copy it over to the
 server along with the Project key that was generated when you first created the Project.
 
-.. code-block:: console
+.. code:: console
 
     $ scp /Users/me/secret/server_secret.pem ubuntu@10.1.2.3:/home/www/server_secret.pem
     $ scp /Users/me/secret/project_secret.pem ubuntu@10.1.2.3:/home/www/project_secret.pem
@@ -107,7 +107,7 @@ server along with the Project key that was generated when you first created the 
 In Python, we're just going to hardcode the path to these keys for quick access.
 
 
-.. code-block:: python
+.. code:: python
 
     import json
     import logging
@@ -166,7 +166,7 @@ IoT Device
 ~~~~~~~~~~
 Just like we did with the server, we need to provision our IoT device.
 
-.. code-block:: console
+.. code:: console
 
     $ oneid-cli provision --project-id d47fedd0-729f-4941-b4bd-2ec4fe0f9ca9 --name "my edge device" --type edge_device
 
@@ -178,7 +178,7 @@ from the `Neustar TDI developer console`_.
 You can print out your Project verifier key by adding a snippet to the previous code
 example.
 
-.. code-block:: python
+.. code:: python
 
    import base64
    project_verifier = base64.b64encode(project_key.public_key_der)
@@ -188,14 +188,14 @@ If you can SSH into your IoT device, you can do the same thing that we did with 
 and copy over the device identity secret key. Since the Neustar TDI and Project verifier keys
 are static for all devices in a Project, we can hard code them in.
 
-.. code-block:: console
+.. code:: console
 
     $ scp /Users/me/secret/device_secret.pem edison@10.1.2.3:/home/root/device_secret.pem
 
 Now that we have the message that was sent to the IoT device, let's check the message's authenticity
 by verifying the digital signatures.
 
-.. code-block:: python
+.. code:: python
 
     from oneid.keychain import Keypair, Credentials
     from oneid.session import DeviceSession

--- a/docs/tutorials/hello-world.rst
+++ b/docs/tutorials/hello-world.rst
@@ -5,7 +5,7 @@ Here is a simple "hello world" message with a digital signature and verified.
 
 Before we can sign or verify any messages, we first need to create a secret key.
 
-.. code-block:: python
+.. code:: python
 
     from oneid import service
     # Directory to save the secret key (should be secure enclave)
@@ -16,7 +16,7 @@ You should now have a secret key pem file that begins with ``-----BEGIN PRIVATE 
 
 Now we can create our "hello world" message and sign it.
 
-.. code-block:: python
+.. code:: python
 
     from oneid.keychain import Keypair
 
@@ -28,7 +28,7 @@ Now we can create our "hello world" message and sign it.
 
 To verify the signature, we need to pass in the message and the signature back into the Keypair.
 
-..  code-block:: python
+..  code:: python
 
     my_key.verify(message, signature)
 
@@ -37,7 +37,7 @@ That's it!
 If you want to see what happens if the message has been tampered with, replace ``hello world`` with
 something else like ``hello universe``.
 
-.. code-block:: python
+.. code:: python
 
     # raises InvalidSignature
     my_key.verify('hello universe', signature)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # from setup.py
-cryptography~=1.7.1
+cryptography~=2.0.2
 requests[security]~=2.9.1
 PyYAML~=3.11
 python-dateutil~=2.4.2

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     package_data={
         'oneid': ['data/*.yaml'],
     },
-    install_requires=['cryptography>=1.7.1,<1.8', 'PyYAML>=3.11,<4',
+    install_requires=['cryptography>=2.0.2,<2.1', 'PyYAML>=3.11,<4',
                       'requests[security]>=2.9.1,<2.10', 'python-dateutil>=2.4.2,<2.5',
                       'pytz>=2017.2', 'six>=1.10.0,<1.11', 'boto3>=1.4.4,<1.5'],
 )

--- a/src/oneid/keychain.py
+++ b/src/oneid/keychain.py
@@ -372,9 +372,8 @@ class Keypair(BaseKeypair):
         sig_s = int_from_bytes(sig_s_bin, 'big')
 
         sig = encode_dss_signature(sig_r, sig_s)
-        signer = self.public_key.verifier(sig, ec.ECDSA(hashes.SHA256()))
-        signer.update(utils.to_bytes(payload))
-        return signer.verify()
+        self.public_key.verify(sig, utils.to_bytes(payload), ec.ECDSA(hashes.SHA256()))
+        return True
 
     def sign(self, payload):
         """
@@ -383,10 +382,7 @@ class Keypair(BaseKeypair):
         :param payload: String (usually jwt payload)
         :return: URL safe base64 signature
         """
-        signer = self._private_key.signer(ec.ECDSA(hashes.SHA256()))
-
-        signer.update(utils.to_bytes(payload))
-        signature = signer.finalize()
+        signature = self._private_key.sign(utils.to_bytes(payload), ec.ECDSA(hashes.SHA256()))
 
         r, s = decode_dss_signature(signature)
 


### PR DESCRIPTION
Move to latest version of https://cryptography.io

Fixes dependency issue at buildthedocs, and other general hygiene issues.